### PR TITLE
Generate an ICS file for the scheduled talks

### DIFF
--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -1,0 +1,109 @@
+- date: 2021-01-04T15:00+01:00
+  presenter: Rob Lewis and Patrick Massot
+  title: Opening remarks
+- date: 2021-01-04T15:15+01:00
+  presenter: Floris van Doorn
+  title: Measure theory
+- date: 2021-01-04T15:45+01:00
+  presenter: Heather Macbeth
+  title: An example of a manifold
+- date: 2021-01-04T16:15+01:00
+  presenter: Ed Ayers
+  title: "Widgets: interactive output in VSCode"
+- date: 2021-01-04T17:00+01:00
+  presenter: Coffee break
+- date: 2021-01-04T17:30+01:00
+  presenter: Leonardo de Moura and Sebastian Ullrich
+  title: An overview of Lean 4
+- date: 2021-01-04T18:30+01:00
+  presenter: Lean 4 Q&A
+- date: 2021-01-04T19:00+01:00
+  title: "Discussion: porting mathlib to Lean 4"
+- date: 2021-01-04T19:30+01:00
+  title: Social time ("workshop dinner")
+
+## Tuesday, January 5
+
+- date: 2021-01-04T12:00+01:00
+  presenter: Jannis Limperg
+  title: Towards general-purpose automation for Lean
+- date: 2021-01-04T12:45+01:00
+  presenter: Chris Hughes
+  title: Word problem for one-relator groups
+- date: 2021-01-04T13:30+01:00
+  presenter: Coffee break
+- date: 2021-01-04T14:00+01:00
+  presenter: Stanislaus Polu
+  title: OpenAI Metamath GPT-f
+- date: 2021-01-04T15:00+01:00
+  presenter: Jason Rute
+  title: Machine learning datasets for Lean
+- date: 2021-01-04T15:45+01:00
+  title: Coffee break
+- date: 2021-01-04T16:15+01:00
+  presenter: Koundinya Vajjha
+  title: "CertRL: Formalizing Convergence Proofs for Value and Policy Iteration in Coq"
+- date: 2021-01-04T16:45+01:00
+  presenter: Yury Kudryashov
+  title: Dynamics on the circle
+- date: 2021-01-04T17:30+01:00
+  title: Social time
+
+## Wednesday, January 6
+
+- date: 2021-01-04T16:00+01:00
+  presenter: Paula Neeley
+  title: Results in modal and dynamic epistemic logic
+- date: 2021-01-04T16:30+01:00
+  presenter: Kenny Lau
+  title: Formalizing Perfectoid Fields
+- date: 2021-01-04T17:00+01:00
+  presenter: Yasmine Sharoda
+  title: Generative Tools for Library Building
+- date: 2021-01-04T17:30+01:00
+  presenter: Coffee break
+- date: 2021-01-04T18:00+01:00
+  presenter: Leonardo de Moura and Sebastian Ullrich
+  title: Metaprogramming in Lean 4
+- date: 2021-01-04T19:00+01:00
+  presenter: Joe Hendrix
+  title: Towards verified decompilation using Lean 4
+- date: 2021-01-04T19:30+01:00
+  presenter: Coffee break
+- date: 2021-01-04T20:00+01:00
+  presenter: Adam Topaz
+  title: Baby steps toward formalizing results in anabelian geometry
+- date: 2021-01-04T20:45+01:00
+  presenter: Peter Nelson
+  title: Formalising matroids
+- date: 2021-01-04T21:15+01:00
+  title: Social time
+
+## Thursday, January 7
+
+- date: 2021-01-04T14:00+01:00
+  presenter: Marie Kerjean
+  title: Complex analysis through a hierarchy of real-analysis structures
+- date: 2021-01-04T14:30+01:00
+  presenter: Damiano Testa
+  title: Mathematical insights from using Lean
+- date: 2021-01-04T15:00+01:00
+  presenter: Amelia Livingston
+  title: Two ways to formalise exterior algebras
+- date: 2021-01-04T15:30+01:00
+  presenter: Coffee break
+- date: 2021-01-04T16:00+01:00
+  presenter: Alena Gusakov
+  title: Formalizing Hall's Marriage Theorem
+- date: 2021-01-04T16:30+01:00
+  title: "Panel/discussion: Teaching with proof assistants"
+- date: 2021-01-04T17:30+01:00
+  title: Coffee break
+- date: 2021-01-04T18:00+01:00
+  presenter: Logan Murphy
+  title: Provably Deductive Assurance Cases
+- date: 2021-01-04T18:30+01:00
+  presenter: Thomas Browning and Patrick Lutz
+  title: Galois theory
+- date: 2021-01-04T19:00+01:00
+  title: Social time

--- a/_data/schedule.yml
+++ b/_data/schedule.yml
@@ -24,86 +24,86 @@
 
 ## Tuesday, January 5
 
-- date: 2021-01-04T12:00+01:00
+- date: 2021-01-05T12:00+01:00
   presenter: Jannis Limperg
   title: Towards general-purpose automation for Lean
-- date: 2021-01-04T12:45+01:00
+- date: 2021-01-05T12:45+01:00
   presenter: Chris Hughes
   title: Word problem for one-relator groups
-- date: 2021-01-04T13:30+01:00
+- date: 2021-01-05T13:30+01:00
   presenter: Coffee break
-- date: 2021-01-04T14:00+01:00
+- date: 2021-01-05T14:00+01:00
   presenter: Stanislaus Polu
   title: OpenAI Metamath GPT-f
-- date: 2021-01-04T15:00+01:00
+- date: 2021-01-05T15:00+01:00
   presenter: Jason Rute
   title: Machine learning datasets for Lean
-- date: 2021-01-04T15:45+01:00
+- date: 2021-01-05T15:45+01:00
   title: Coffee break
-- date: 2021-01-04T16:15+01:00
+- date: 2021-01-05T16:15+01:00
   presenter: Koundinya Vajjha
   title: "CertRL: Formalizing Convergence Proofs for Value and Policy Iteration in Coq"
-- date: 2021-01-04T16:45+01:00
+- date: 2021-01-05T16:45+01:00
   presenter: Yury Kudryashov
   title: Dynamics on the circle
-- date: 2021-01-04T17:30+01:00
+- date: 2021-01-05T17:30+01:00
   title: Social time
 
 ## Wednesday, January 6
 
-- date: 2021-01-04T16:00+01:00
+- date: 2021-01-06T16:00+01:00
   presenter: Paula Neeley
   title: Results in modal and dynamic epistemic logic
-- date: 2021-01-04T16:30+01:00
+- date: 2021-01-06T16:30+01:00
   presenter: Kenny Lau
   title: Formalizing Perfectoid Fields
-- date: 2021-01-04T17:00+01:00
+- date: 2021-01-06T17:00+01:00
   presenter: Yasmine Sharoda
   title: Generative Tools for Library Building
-- date: 2021-01-04T17:30+01:00
+- date: 2021-01-06T17:30+01:00
   presenter: Coffee break
-- date: 2021-01-04T18:00+01:00
+- date: 2021-01-06T18:00+01:00
   presenter: Leonardo de Moura and Sebastian Ullrich
   title: Metaprogramming in Lean 4
-- date: 2021-01-04T19:00+01:00
+- date: 2021-01-06T19:00+01:00
   presenter: Joe Hendrix
   title: Towards verified decompilation using Lean 4
-- date: 2021-01-04T19:30+01:00
+- date: 2021-01-06T19:30+01:00
   presenter: Coffee break
-- date: 2021-01-04T20:00+01:00
+- date: 2021-01-06T20:00+01:00
   presenter: Adam Topaz
   title: Baby steps toward formalizing results in anabelian geometry
-- date: 2021-01-04T20:45+01:00
+- date: 2021-01-06T20:45+01:00
   presenter: Peter Nelson
   title: Formalising matroids
-- date: 2021-01-04T21:15+01:00
+- date: 2021-01-06T21:15+01:00
   title: Social time
 
 ## Thursday, January 7
 
-- date: 2021-01-04T14:00+01:00
+- date: 2021-01-07T14:00+01:00
   presenter: Marie Kerjean
   title: Complex analysis through a hierarchy of real-analysis structures
-- date: 2021-01-04T14:30+01:00
+- date: 2021-01-07T14:30+01:00
   presenter: Damiano Testa
   title: Mathematical insights from using Lean
-- date: 2021-01-04T15:00+01:00
+- date: 2021-01-07T15:00+01:00
   presenter: Amelia Livingston
   title: Two ways to formalise exterior algebras
-- date: 2021-01-04T15:30+01:00
+- date: 2021-01-07T15:30+01:00
   presenter: Coffee break
-- date: 2021-01-04T16:00+01:00
+- date: 2021-01-07T16:00+01:00
   presenter: Alena Gusakov
   title: Formalizing Hall's Marriage Theorem
-- date: 2021-01-04T16:30+01:00
+- date: 2021-01-07T16:30+01:00
   title: "Panel/discussion: Teaching with proof assistants"
-- date: 2021-01-04T17:30+01:00
+- date: 2021-01-07T17:30+01:00
   title: Coffee break
-- date: 2021-01-04T18:00+01:00
+- date: 2021-01-07T18:00+01:00
   presenter: Logan Murphy
   title: Provably Deductive Assurance Cases
-- date: 2021-01-04T18:30+01:00
+- date: 2021-01-07T18:30+01:00
   presenter: Thomas Browning and Patrick Lutz
   title: Galois theory
-- date: 2021-01-04T19:00+01:00
+- date: 2021-01-07T19:00+01:00
   title: Social time

--- a/schedule.ics
+++ b/schedule.ics
@@ -14,7 +14,7 @@ SUMMARY:{{ post.title }}
 CLASS:PUBLIC
 DTSTART:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
 {% if forloop.last %}DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
-{% else %}{% assign next_i = forloop.index0 | plus: 1 %}DTEND:{{ talks_by_day[next_i].date | date: "%Y%m%dT%H%M%SZ" }}
+{% else %}{% assign next_i = forloop.index0 | plus: 1 %}DTEND:{{ day.items[next_i].date | date: "%Y%m%dT%H%M%SZ" }}
 {% endif %}DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 END:VEVENT
 {% endfor %}

--- a/schedule.ics
+++ b/schedule.ics
@@ -1,0 +1,16 @@
+---
+layout: none
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:http://lean-prover-community.github.io/
+METHOD:PUBLISH
+{% for post in site.data.schedule %}BEGIN:VEVENT
+UID:{{ post.date | date: "%Y%m%d" }}@lean-prover-community.github.io
+SUMMARY:{{ post.title }}
+CLASS:PUBLIC
+DTSTART:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
+DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
+DTSTAMP:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
+END:VEVENT{% endfor %}
+END:VCALENDAR

--- a/schedule.ics
+++ b/schedule.ics
@@ -5,7 +5,7 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:http://lean-prover-community.github.io/
 METHOD:PUBLISH
-{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%Y%M%D'" %}
+{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%Y%m%d'" %}
 {% for day in talks_by_day %}
 {% for post in day.items %}
 BEGIN:VEVENT
@@ -14,7 +14,7 @@ SUMMARY:{{ post.title }}
 CLASS:PUBLIC
 DTSTART:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
 {% if forloop.last %}DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
-{% else %}{% assign next_i = forloop.index0 | plus: 1 %}DTEND:{{ day.items[next_i].date | date: "%Y%m%dT%H%M%SZ" }}
+{% else %}{% assign next_i = forloop.index0 | plus: 1 %}{% assign next_post = day.items[next_i] %}DTEND:{{ next_post.date | date: "%Y%m%dT%H%M%SZ" }}
 {% endif %}DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 END:VEVENT
 {% endfor %}

--- a/schedule.ics
+++ b/schedule.ics
@@ -5,12 +5,14 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:http://lean-prover-community.github.io/
 METHOD:PUBLISH
-{% for post in site.data.schedule %}BEGIN:VEVENT
+{% for post in site.data.schedule %}
+BEGIN:VEVENT
 UID:{{ post.date | date: "%Y%m%d" }}@lean-prover-community.github.io
 SUMMARY:{{ post.title }}
 CLASS:PUBLIC
 DTSTART:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
 DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
-DTSTAMP:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
-END:VEVENT{% endfor %}
+DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
+END:VEVENT
+{% endfor %}
 END:VCALENDAR

--- a/schedule.ics
+++ b/schedule.ics
@@ -5,14 +5,21 @@ BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:http://lean-prover-community.github.io/
 METHOD:PUBLISH
-{% for post in site.data.schedule %}
+{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%Y%M%D'" %}
+{% for day in talks_by_day %}
+{% for post in day.items %}
 BEGIN:VEVENT
 UID:{{ post.date | date: "%Y%m%d" }}@lean-prover-community.github.io
 SUMMARY:{{ post.title }}
 CLASS:PUBLIC
 DTSTART:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
+{% if forloop.last %}
 DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
+{% else %}
+DTEND:{{ talks_by_day[forloop.index + 1].date | date: "%Y%m%dT%H%M%SZ" }}
+{% endif %}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 END:VEVENT
+{% endfor %}
 {% endfor %}
 END:VCALENDAR

--- a/schedule.ics
+++ b/schedule.ics
@@ -13,12 +13,9 @@ UID:{{ post.date | date: "%Y%m%d" }}@lean-prover-community.github.io
 SUMMARY:{{ post.title }}
 CLASS:PUBLIC
 DTSTART:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
-{% if forloop.last %}
-DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
-{% else %}
-DTEND:{{ talks_by_day[forloop.index + 1].date | date: "%Y%m%dT%H%M%SZ" }}
-{% endif %}
-DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
+{% if forloop.last %}DTEND:{{ post.date | date: "%Y%m%dT%H%M%SZ" }}
+{% else %}{% assign next_i = forloop.index0 | plus: 1 %}DTEND:{{ talks_by_day[next_i].date | date: "%Y%m%dT%H%M%SZ" }}
+{% endif %}DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 END:VEVENT
 {% endfor %}
 {% endfor %}

--- a/schedule.md
+++ b/schedule.md
@@ -22,6 +22,8 @@ We will open the room before and after each day's events.
 The social time on Monday is "official":
 if you're only planning to attend one social event, try to make it this one.
 
+A web calendar can be found [here](./calendar.ics)
+
 ## Prerecorded Talks
 
 Some talks were added to our program too late to fit in the live schedule.
@@ -34,7 +36,7 @@ look for them on [wonder.me](https://www.wonder.me/)!
 | Wednesday, Jan 6<br><time datetime="2021-01-04T21:15+01:00">9:15pm CET</time> | Vaibhav Karve |
 | Thursday, Jan 7<br><time datetime="2021-01-04T19:00+01:00">7:00pm CET</time> | Alex Best |
 
-{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%A, %B %d'" %}
+{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%A, %B %e'" %}
 {% for day in talks_by_day %}
 <h2>{{ day.name }}</h2>
 <table>

--- a/schedule.md
+++ b/schedule.md
@@ -34,7 +34,7 @@ look for them on [wonder.me](https://www.wonder.me/)!
 | Wednesday, Jan 6<br><time datetime="2021-01-04T21:15+01:00">9:15pm CET</time> | Vaibhav Karve |
 | Thursday, Jan 7<br><time datetime="2021-01-04T19:00+01:00">7:00pm CET</time> | Alex Best |
 
-{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%A %B %w'" %}
+{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%A, %B %d'" %}
 {% for day in talks_by_day %}
 <h2>{{ day.name }}</h2>
 <table>

--- a/schedule.md
+++ b/schedule.md
@@ -36,8 +36,13 @@ look for them on [wonder.me](https://www.wonder.me/)!
 
 {% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%A %B %w'" %}
 {% for day in talks_by_day %}
-## {{ day.title }}
-testing
+<h2>{{ day.name }}</h2>
+<table>
+  {% for talk in day.items %}
+  <tr><td><time datetime="{{ talk.date }}">{{ talk.date | date: "%h:%M %p CET" }}</time></td>
+    <td>{{post.presenter}}<br /><em>{{post.title}}</em></td></tr>
+  {% endfor %}
+</table>
 {% endfor %}
 
 ## Monday, January 4

--- a/schedule.md
+++ b/schedule.md
@@ -38,67 +38,10 @@ look for them on [wonder.me](https://www.wonder.me/)!
 {% for day in talks_by_day %}
 <h2>{{ day.name }}</h2>
 <table>
+  <tr><th>Time</th><th>Speaker</th></tr>
   {% for talk in day.items %}
   <tr><td><time datetime="{{ talk.date }}">{{ talk.date | date: "%h:%M %p CET" }}</time></td>
-    <td>{{post.presenter}}<br /><em>{{post.title}}</em></td></tr>
+      <td>{{talk.presenter}}<br /><em>{{talk.title}}</em></td></tr>
   {% endfor %}
 </table>
 {% endfor %}
-
-## Monday, January 4
-
-| Time      | Speaker            |
-| --------- | ------------------ |
-| <time datetime="2021-01-04T15:00+01:00">3:00pm CET</time> | Rob Lewis and Patrick Massot<br>*Opening remarks* |
-| <time datetime="2021-01-04T15:15+01:00">3:15pm CET</time> | Floris van Doorn<br>*Measure theory* |
-| <time datetime="2021-01-04T15:45+01:00">3:45pm CET</time> | Heather Macbeth<br>*An example of a manifold* |
-| <time datetime="2021-01-04T16:15+01:00">4:15pm CET</time> | Ed Ayers<br>*Widgets: interactive output in VSCode* |
-| <time datetime="2021-01-04T17:00+01:00">5:00pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T17:30+01:00">5:30pm CET</time> | Leonardo de Moura and Sebastian Ullrich<br>*An overview of Lean 4* |
-| <time datetime="2021-01-04T18:30+01:00">6:30pm CET</time> | Lean 4 Q&A |
-| <time datetime="2021-01-04T19:00+01:00">7:00pm CET</time> | Discussion: porting mathlib to Lean 4 |
-| <time datetime="2021-01-04T19:30+01:00">7:30pm CET</time> | Social time ("workshop dinner") |
-
-## Tuesday, January 5
-
-| Time      | Speaker            |
-| --------- | ------------------ |
-| <time datetime="2021-01-04T12:00+01:00">12:00pm CET</time> | Jannis Limperg<br>*Towards general-purpose automation for Lean* |
-| <time datetime="2021-01-04T12:45+01:00">12:45pm CET</time> | Chris Hughes<br>*Word problem for one-relator groups* |
-| <time datetime="2021-01-04T13:30+01:00">1:30pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T14:00+01:00">2:00pm CET</time> | Stanislaus Polu<br>*OpenAI Metamath GPT-f* |
-| <time datetime="2021-01-04T15:00+01:00">3:00pm CET</time> | Jason Rute<br>*Machine learning datasets for Lean* |
-| <time datetime="2021-01-04T15:45+01:00">3:45pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T16:15+01:00">4:15pm CET</time> | Koundinya Vajjha<br>*CertRL: Formalizing Convergence Proofs for Value and Policy Iteration in Coq* |
-| <time datetime="2021-01-04T16:45+01:00">4:45pm CET</time> | Yury Kudryashov<br>*Dynamics on the circle* |
-| <time datetime="2021-01-04T17:30+01:00">5:30pm CET</time> | Social time |
-
-## Wednesday, January 6
-
-| Time      | Speaker            |
-| --------- | ------------------ |
-| <time datetime="2021-01-04T16:00+01:00">4:00pm CET</time> | Paula Neeley<br>*Results in modal and dynamic epistemic logic* |
-| <time datetime="2021-01-04T16:30+01:00">4:30pm CET</time> | Kenny Lau<br>*Formalizing Perfectoid Fields* |
-| <time datetime="2021-01-04T17:00+01:00">5:00pm CET</time> | Yasmine Sharoda<br>*Generative Tools for Library Building* |
-| <time datetime="2021-01-04T17:30+01:00">5:30pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T18:00+01:00">6:00pm CET</time> | Leonardo de Moura and Sebastian Ullrich<br>*Metaprogramming in Lean 4* |
-| <time datetime="2021-01-04T19:00+01:00">7:00pm CET</time> | Joe Hendrix<br>*Towards verified decompilation using Lean 4* |
-| <time datetime="2021-01-04T19:30+01:00">7:30pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T20:00+01:00">8:00pm CET</time> | Adam Topaz<br>*Baby steps toward formalizing results in anabelian geometry* |
-| <time datetime="2021-01-04T20:45+01:00">8:45pm CET</time> | Peter Nelson<br>*Formalising matroids* |
-| <time datetime="2021-01-04T21:15+01:00">9:15pm CET</time> | Social time |
-
-## Thursday, January 7
-
-| Time      | Speaker            |
-| --------- | ------------------ |
-| <time datetime="2021-01-04T14:00+01:00">2:00pm CET</time> | Marie Kerjean<br>*Complex analysis through a hierarchy of real-analysis structures* |
-| <time datetime="2021-01-04T14:30+01:00">2:30pm CET</time> | Damiano Testa<br>*Mathematical insights from using Lean* |
-| <time datetime="2021-01-04T15:00+01:00">3:00pm CET</time> | Amelia Livingston<br>*Two ways to formalise exterior algebras* |
-| <time datetime="2021-01-04T15:30+01:00">3:30pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T16:00+01:00">4:00pm CET</time> | Alena Gusakov<br>*Formalizing Hall's Marriage Theorem* |
-| <time datetime="2021-01-04T16:30+01:00">4:30pm CET</time> | Panel/discussion: Teaching with proof assistants |
-| <time datetime="2021-01-04T17:30+01:00">5:30pm CET</time> | Coffee break |
-| <time datetime="2021-01-04T18:00+01:00">6:00pm CET</time> | Logan Murphy<br>*Provably Deductive Assurance Cases* |
-| <time datetime="2021-01-04T18:30+01:00">6:30pm CET</time> | Thomas Browning and Patrick Lutz<br>*Galois theory* |
-| <time datetime="2021-01-04T19:00+01:00">7:00pm CET</time> | Social time |

--- a/schedule.md
+++ b/schedule.md
@@ -22,7 +22,7 @@ We will open the room before and after each day's events.
 The social time on Monday is "official":
 if you're only planning to attend one social event, try to make it this one.
 
-A web calendar can be found [here](./calendar.ics)
+A web calendar can be found [here](./schedule.ics)
 
 ## Prerecorded Talks
 

--- a/schedule.md
+++ b/schedule.md
@@ -34,6 +34,11 @@ look for them on [wonder.me](https://www.wonder.me/)!
 | Wednesday, Jan 6<br><time datetime="2021-01-04T21:15+01:00">9:15pm CET</time> | Vaibhav Karve |
 | Thursday, Jan 7<br><time datetime="2021-01-04T19:00+01:00">7:00pm CET</time> | Alex Best |
 
+{% assign talks_by_day = site.data.schedule | group_by_exp:"post", "post.date | date: '%A %B %w'" %}
+{% for day in talks_by_day %}
+## {{ day.title }}
+testing
+{% endfor %}
 
 ## Monday, January 4
 


### PR DESCRIPTION
I haven't tested the ICS file in a calendar program, but it's now definitely synced to the web page.

https://eric-wieser.github.io/lt2021/schedule.html

The UTC+1 timezone in the yaml file is awkward for ICS, as the two choices there are UTC or painful -  so right now all the times are off by an hour:

https://larrybolt.github.io/online-ics-feed-viewer/#feed=https%3A//eric-wieser.github.io/lt2021/schedule.ics&cors=true&title=My%20Feed&hideinput=false